### PR TITLE
Internal Transcoding Works

### DIFF
--- a/encoder/as3/README.md
+++ b/encoder/as3/README.md
@@ -1,3 +1,30 @@
+
+## Setup
+
+1. Ensure that you are running on either a Cygwin or Mac environment.
+
+2. Download air sdk 18.0 from https://helpx.adobe.com/air/kb/archived-air-sdk-version.html
+
+3. Navigate to `frameworks/flex-config.xml` and at about line 46, replace as follows:
+
+   From
+   ```
+   <external-library-path>
+    <path-element>libs/player/{targetPlayerMajorVersion}.{targetPlayerMinorVersion}/playerglobal.swc</path-element>
+   </e xternal-library-path>
+   ```
+   
+   To
+   ```
+   <external-library-path>
+    <path-element>libs/player/18.0/playerglobal.swc</path-element>
+   </e xternal-library-path>
+   ```
+
+4. Run `build.sh` either from Cygwin or from a Mac terminal window.
+
+   Note: On Cygwin, the internal call to make may fail on building sha512.o due to an error: "Couldn't fork: Resource temporarily unavailable". In such case, make sure that there are no other Cygwin or Cygwin-related processes running except the current terminal window; close/terminate them if they exists and rerun `build.sh`.
+
 ## Inspired by
 * http://blog.elliotblackburn.co.uk/ffmpeg-with-flascccrossbridge/
 * http://stackoverflow.com/questions/13690290/how-to-compile-ffmpeg-with-the-new-flascc-compiler
@@ -15,25 +42,3 @@
 * https://github.com/normanzb/encoder-mp3
 * https://github.com/soywiz/as3libwebp
 * https://github.com/claus/libtess2.swc
-
-## Setup
-
-https://helpx.adobe.com/air/kb/archived-air-sdk-version.html
-
-Download air sdk 18.0
-
-Navigate to `frameworks/flex-config.xml` and at about line 46, replace as follows:
-
-From
-```
-<external-library-path>
- <path-element>libs/player/{targetPlayerMajorVersion}.{targetPlayerMinorVersion}/playerglobal.swc</path-element>
-</e xternal-library-path>
-```
-
-To
-```
-<external-library-path>
- <path-element>libs/player/18.0/playerglobal.swc</path-element>
-</e xternal-library-path>
-```

--- a/encoder/as3/README.md
+++ b/encoder/as3/README.md
@@ -25,6 +25,14 @@
 
    Note: On Cygwin, the internal call to make may fail on building sha512.o due to an error: "Couldn't fork: Resource temporarily unavailable". In such case, make sure that there are no other Cygwin or Cygwin-related processes running except the current terminal window; close/terminate them if they exists and rerun `build.sh`.
 
+5. Once `build.sh` has built, which configures and compiles ffmpeg internally, you can compile just your project by running:
+
+   ```
+   source setenv.sh
+   make
+   make install
+   ```
+
 ## Inspired by
 * http://blog.elliotblackburn.co.uk/ffmpeg-with-flascccrossbridge/
 * http://stackoverflow.com/questions/13690290/how-to-compile-ffmpeg-with-the-new-flascc-compiler

--- a/encoder/as3/build.sh
+++ b/encoder/as3/build.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 
-. setenv.sh
+function exit_on_fail {
+    "$@"
+    local status=$?
+    if [ $status -ne 0 ]; then
+        exit
+    fi
+    return $status
+}
+
+exit_on_fail source setenv.sh
 
 rm -Rf dist
 mkdir dist
@@ -12,12 +21,12 @@ cd ../ffmpeg
 if [ -f "config.mak" ]
 then
     echo "Cleaning past configuration"
-    make clean
+    exit_on_fail make clean
     echo "Cleaned past configuration"
 fi
 
 echo "Starting ffmpeg configuration"
-./configure \
+exit_on_fail ./configure \
     --prefix=../as3/dist \
 \
     --disable-runtime-cpudetect \
@@ -78,12 +87,12 @@ echo "Starting ffmpeg configuration"
 
 echo "Finished ffmpeg configuration"
 
-make
-make install
-make clean
+exit_on_fail make
+exit_on_fail make install
+exit_on_fail make clean
 
 cd ../as3
 
-make clean
-make
-make install
+exit_on_fail make clean
+exit_on_fail make
+exit_on_fail make install

--- a/encoder/as3/setenv.sh
+++ b/encoder/as3/setenv.sh
@@ -4,11 +4,11 @@
 case "$(uname -s)" in
     CYGWIN*) #On windows
         BASE_DIR=/cygdrive/c/EnglishCentral
-        printf "Environment set for Windows platform.\nQuit if incorrect.\n"
+        printf "Environment set for Windows platform.\n"
         ;;
     Darwin) #On mac
         BASE_DIR=/usr/local
-        printf "Environment set for Apple platform.\nQuit if incorrect.\n"
+        printf "Environment set for Apple platform.\n"
         ;;
     *)
         printf "Error: Running on an unsupported environment."
@@ -23,4 +23,6 @@ export COMPC=$FLEX/bin/compc
 export ASC2="java -jar $FLASCC/usr/lib/asc2.jar -merge -md -parallel"
 export SWIG=$FLASCC/usr/bin/swig
 
+#This is the path to the FLASCC crossbridge compiler tools. It is used to directly
+# access those tools via absolute path rather than relying on the $PATH variable.
 export FLASCC_BIN_PATH=$FLASCC/usr/bin

--- a/encoder/as3/src/com/marstonstudio/crossusermedia/encoder/Encoder.as
+++ b/encoder/as3/src/com/marstonstudio/crossusermedia/encoder/Encoder.as
@@ -46,14 +46,19 @@ package com.marstonstudio.crossusermedia.encoder {
         }
 
         public function init(inputFormat:String, inputCodec:String, inputSampleRate:int, inputChannels:int, outputCodec:String, outputFormat:String, outputSampleRate:int, outputChannels:int, outputBitRate:int):void {
+           
             com.marstonstudio.crossusermedia.encoder.flascc.init(inputFormat, inputCodec, inputSampleRate, inputChannels, outputCodec, outputFormat, outputSampleRate, outputChannels, outputBitRate);
+
         }
 
         public function load(input:ByteArray):void {
+            //Convert the input byte array into a C friendly type with its length
             var inputLength:int = input.length;
             var inputPointer:int = CModule.malloc(inputLength);
             CModule.writeBytes(inputPointer, inputLength, input);
+            
             com.marstonstudio.crossusermedia.encoder.flascc.loadPointer(inputPointer, inputLength);
+
             CModule.free(inputPointer);
         }
         

--- a/encoder/as3/src/com/marstonstudio/crossusermedia/encoder/Encoder.as
+++ b/encoder/as3/src/com/marstonstudio/crossusermedia/encoder/Encoder.as
@@ -45,8 +45,8 @@ package com.marstonstudio.crossusermedia.encoder {
             }
         }
 
-        public function init(inputFormat:String, inputSampleRate:int, inputChannels:int, outputCodec:String, outputFormat:String, outputSampleRate:int, outputChannels:int, outputBitRate:int):void {
-            com.marstonstudio.crossusermedia.encoder.flascc.init(inputFormat, inputSampleRate, inputChannels, outputCodec, outputFormat, outputSampleRate, outputChannels, outputBitRate);
+        public function init(inputFormat:String, inputCodec:String, inputSampleRate:int, inputChannels:int, outputCodec:String, outputFormat:String, outputSampleRate:int, outputChannels:int, outputBitRate:int):void {
+            com.marstonstudio.crossusermedia.encoder.flascc.init(inputFormat, inputCodec, inputSampleRate, inputChannels, outputCodec, outputFormat, outputSampleRate, outputChannels, outputBitRate);
         }
 
         public function load(input:ByteArray):void {

--- a/encoder/c/as3api.c
+++ b/encoder/c/as3api.c
@@ -9,13 +9,15 @@
 
 void as3_init() __attribute__((
         used,
-        annotate("as3sig:public function init(inputFormat:String, inputSampleRate:int, inputChannels:int, outputCodec:String, outputFormat:String, outputSampleRate:int, outputChannels:int, outputBitRate:int):void"),
+        annotate("as3sig:public function init(inputFormat:String, inputCodec:String, inputSampleRate:int, inputChannels:int, outputCodec:String, outputFormat:String, outputSampleRate:int, outputChannels:int, outputBitRate:int):void"),
         annotate("as3package:com.marstonstudio.crossusermedia.encoder.flascc")
     ));
 
-void as3_init(const char *i_format, int i_sample_rate, int i_channels, const char *o_codec, const char *o_format, int o_sample_rate, int o_channels, int o_bit_rate) {
-
-    AS3_MallocString(i_format, inputFormat);
+void as3_init(const char *i_format_name, const char *i_codec_name, int i_sample_rate, int i_channels,
+              const char *o_codec, const char *o_format, int o_sample_rate, int o_channels, int o_bit_rate)
+{
+    AS3_MallocString(i_format_name, inputFormat);
+    AS3_MallocString(i_codec_name, inputCodec);
     AS3_GetScalarFromVar(i_sample_rate, inputSampleRate);
     AS3_GetScalarFromVar(i_channels, inputChannels);
     AS3_MallocString(o_codec, outputCodec);
@@ -24,9 +26,11 @@ void as3_init(const char *i_format, int i_sample_rate, int i_channels, const cha
     AS3_GetScalarFromVar(o_channels, outputChannels);
     AS3_GetScalarFromVar(o_bit_rate, outputBitRate);
 
-    init(i_format, i_sample_rate, i_channels, o_codec, o_format, o_sample_rate, o_channels, o_bit_rate);
+    init(i_format_name, i_codec_name, i_sample_rate, i_channels, o_codec,
+         o_format, o_sample_rate, o_channels, o_bit_rate);
 
-    free((char*)i_format);
+    free((char*)i_format_name);
+    free((char*)i_codec_name);
     free((char*)o_codec);
     free((char*)o_format);
 }

--- a/encoder/c/as3api.c
+++ b/encoder/c/as3api.c
@@ -13,26 +13,27 @@ void as3_init() __attribute__((
         annotate("as3package:com.marstonstudio.crossusermedia.encoder.flascc")
     ));
 
-void as3_init(const char *i_format_name, const char *i_codec_name, int i_sample_rate, int i_channels,
-              const char *o_codec, const char *o_format, int o_sample_rate, int o_channels, int o_bit_rate)
+void as3_init(const char *i_format_name, const char *i_codec_name, int i_sample_rate,
+              int i_channels, const char *o_codec_name, const char *o_format_name,
+              int o_sample_rate, int o_channels, int o_bit_rate)
 {
     AS3_MallocString(i_format_name, inputFormat);
     AS3_MallocString(i_codec_name, inputCodec);
     AS3_GetScalarFromVar(i_sample_rate, inputSampleRate);
     AS3_GetScalarFromVar(i_channels, inputChannels);
-    AS3_MallocString(o_codec, outputCodec);
-    AS3_MallocString(o_format, outputFormat);
+    AS3_MallocString(o_codec_name, outputCodec);
+    AS3_MallocString(o_format_name, outputFormat);
     AS3_GetScalarFromVar(o_sample_rate, outputSampleRate);
     AS3_GetScalarFromVar(o_channels, outputChannels);
     AS3_GetScalarFromVar(o_bit_rate, outputBitRate);
 
-    init(i_format_name, i_codec_name, i_sample_rate, i_channels, o_codec,
-         o_format, o_sample_rate, o_channels, o_bit_rate);
+    init(i_format_name, i_codec_name, i_sample_rate, i_channels, o_codec_name,
+         o_format_name, o_sample_rate, o_channels, o_bit_rate);
 
     free((char*)i_format_name);
     free((char*)i_codec_name);
-    free((char*)o_codec);
-    free((char*)o_format);
+    free((char*)o_codec_name);
+    free((char*)o_format_name);
 }
 
 void as3_load_pointer() __attribute__((
@@ -41,11 +42,11 @@ void as3_load_pointer() __attribute__((
         annotate("as3package:com.marstonstudio.crossusermedia.encoder.flascc")
     ));
 
-void as3_load_pointer(uint8_t *i_data, int i_length) {
-
-    AS3_GetScalarFromVar((uint8_t *)i_data, inputPointer);
+void as3_load_pointer(uint8_t *i_data, int i_length)
+{
+    AS3_GetScalarFromVar((uint8_t*)i_data, inputPointer);
     AS3_GetScalarFromVar(i_length, inputLength);
-
+    
     load(i_data, i_length);
 }
 
@@ -55,7 +56,8 @@ void as3_flush_pointer() __attribute__((
         annotate("as3package:com.marstonstudio.crossusermedia.encoder.flascc")
     ));
 
-void as3_flush_pointer() {
+void as3_flush_pointer()
+{
     int o_data = (int)flush();
     AS3_Return(o_data);
 }
@@ -66,7 +68,8 @@ void as3_get_output_sample_rate() __attribute__((
         annotate("as3package:com.marstonstudio.crossusermedia.encoder.flascc")
     ));
 
-void as3_get_output_sample_rate() {
+void as3_get_output_sample_rate()
+{
     int o_sample_rate = get_output_sample_rate();
     AS3_Return(o_sample_rate);
 }
@@ -77,7 +80,8 @@ void as3_get_output_format() __attribute__((
         annotate("as3package:com.marstonstudio.crossusermedia.encoder.flascc")
     ));
 
-void as3_get_output_format() {
+void as3_get_output_format()
+{
     char *o_format = (char*) get_output_format();
 
     AS3_DeclareVar(outputFormat, String);
@@ -91,7 +95,8 @@ void as3_get_output_length() __attribute__((
         annotate("as3package:com.marstonstudio.crossusermedia.encoder.flascc")
     ));
 
-void as3_get_output_length() {
+void as3_get_output_length()
+{
     int o_length = get_output_length();
     AS3_Return(o_length);
 }
@@ -102,7 +107,8 @@ void as3_dispose() __attribute__((
         annotate("as3package:com.marstonstudio.crossusermedia.encoder.flascc")
     ));
 
-void as3_dispose(int status) {
+void as3_dispose(int status)
+{
     AS3_GetScalarFromVar(status, status);
     dispose(status);
 }

--- a/microphone/src/test/flex/TestApp.as
+++ b/microphone/src/test/flex/TestApp.as
@@ -145,6 +145,7 @@ public class TestApp {
             var rootSprite:Sprite = new Sprite();
             container.addChild(rootSprite);
 
+            const inputFormat:String = 'f32be';
             const inputCodec:String = 'pcm_f32be';
             const inputSampleRate:int = 16000;
             const inputChannels:int = 1;
@@ -155,9 +156,10 @@ public class TestApp {
             const outputBitRate:int = 32000;
 
             var encoder:Encoder = new Encoder(rootSprite);
-            encoder.init(inputCodec, inputSampleRate, inputChannels, outputCodec, outputFormat, outputSampleRate, outputChannels, outputBitRate);
+            encoder.init(inputFormat, inputCodec, inputSampleRate, inputChannels, outputCodec,
+                outputFormat, outputSampleRate, outputChannels, outputBitRate);
             encoder.load(audioPcmAsset);
-            //ADDED
+            //ADDED comments
             //var output:ByteArray = encoder.flush();
             //var outputBytesAvailable:int = output.bytesAvailable;
             var outputBytesAvailable:int = encoder.getOutputLength();

--- a/microphone/src/test/flex/TestApp.as
+++ b/microphone/src/test/flex/TestApp.as
@@ -159,10 +159,9 @@ public class TestApp {
             encoder.init(inputFormat, inputCodec, inputSampleRate, inputChannels, outputCodec,
                 outputFormat, outputSampleRate, outputChannels, outputBitRate);
             encoder.load(audioPcmAsset);
-            //ADDED comments
-            //var output:ByteArray = encoder.flush();
-            //var outputBytesAvailable:int = output.bytesAvailable;
-            var outputBytesAvailable:int = encoder.getOutputLength();
+            var output:ByteArray = encoder.flush();
+            var outputBytesAvailable:int = output.bytesAvailable;
+            //ADDED var outputBytesAvailable:int = encoder.getOutputLength();
 
             var encoderOutputFormat:String = encoder.getOutputFormat();
             var encoderOutputSampleRate:int = encoder.getOutputSampleRate();

--- a/microphone/src/test/flex/TestApp.as
+++ b/microphone/src/test/flex/TestApp.as
@@ -145,8 +145,8 @@ public class TestApp {
             var rootSprite:Sprite = new Sprite();
             container.addChild(rootSprite);
 
-            const inputFormat:String = 'f32be';
             const inputCodec:String = 'pcm_f32be';
+            const inputFormat:String = 'f32be';
             const inputSampleRate:int = 16000;
             const inputChannels:int = 1;
             const outputCodec:String = 'aac';

--- a/microphone/src/test/flex/TestApp.as
+++ b/microphone/src/test/flex/TestApp.as
@@ -157,8 +157,10 @@ public class TestApp {
             var encoder:Encoder = new Encoder(rootSprite);
             encoder.init(inputCodec, inputSampleRate, inputChannels, outputCodec, outputFormat, outputSampleRate, outputChannels, outputBitRate);
             encoder.load(audioPcmAsset);
-            var output:ByteArray = encoder.flush();
-            var outputBytesAvailable:int = output.bytesAvailable;
+            //ADDED
+            //var output:ByteArray = encoder.flush();
+            //var outputBytesAvailable:int = output.bytesAvailable;
+            var outputBytesAvailable:int = encoder.getOutputLength();
 
             var encoderOutputFormat:String = encoder.getOutputFormat();
             var encoderOutputSampleRate:int = encoder.getOutputSampleRate();


### PR DESCRIPTION
The transcoding of the input audio works internally. The input pcm data is first decoded and resampled into the internal ffmpeg format, shoved into a fifo, and then re-encoded into the desired aac output. Also, the load function works in an synchronous fashion with a locking mechanism. This mechanism will error if a load call is made while another load is still in function.

As it appear, the flash wrapper has trouble taking out the transcoded data from C.