### PR TITLE
Fixed encoder choppiness

### DIFF
--- a/microphone/src/main/flex/com/marstonstudio/crossusermedia/microphone/Recorder.as
+++ b/microphone/src/main/flex/com/marstonstudio/crossusermedia/microphone/Recorder.as
@@ -67,7 +67,7 @@ import flash.utils.getTimer;
         private const _outputFormat:String = "mp4";
         private const _outputCodec:String = "aac";
         
-        private const _outputBitRate:int = 32000;
+        private const _outputBitRate:int = 48000;
         
         private var _startTime:uint;
         private var _microphone:Microphone;


### PR DESCRIPTION
Encoder choppiness was due to calling the `load` function many times over and over while giving it little bits of data.

Originally, any extra audio samples still in the `fifo` (after all frame sized bits of data were processed) would be flushed, transcoded, and written at the end of each `load` call. This is what caused the choppiness.

By moving the flushing, transcoding, and writing of the extra audio samples left in the `fifo` to the `flush` function solves the choppiness issue.